### PR TITLE
[12.0][FIX] overwrite completely method _get_date_end.

### DIFF
--- a/weni_product_contract_custom/models/sale_order_line.py
+++ b/weni_product_contract_custom/models/sale_order_line.py
@@ -14,7 +14,11 @@ class SaleOrderLine(models.Model):
         # of items. In this case we are multiplying by 12.
 
         self.ensure_one()
-        super()._get_date_end()
+
+        # It is necessary to completely overwrite this method because when selling a large amount of the product, the
+        # system returns an error when calculating the original end date since there was an overflow of the allowed
+        # range of years.
+        # super()._get_date_end()
 
         contract_line_model = self.env["contract.line"]
         date_end = (


### PR DESCRIPTION
It is necessary to completely override this method because when selling a large quantity of the product, the system returns an error when calculating the original end date due to the range of years allowed.